### PR TITLE
Fix Dockerfile for upstream changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM centos:7
 RUN yum clean all && \
     yum -y -q update && \
     yum -y -q install epel-release && yum -y update && \
-    yum -y -q install cronie python-pip python34 python-devel python34-devel python34-pip git knot jq gcc bind-utils && \
-    yum -y -q install unbound openvpn strongswan kmod letsencrypt vim curl socat perl-JSON-PP.noarch && \
+    yum -y -q install cronie python-pip python34 python-devel python34-devel python34-pip git jq gcc bind-utils && \
+    yum -y -q install unbound openvpn strongswan kmod letsencrypt vim curl socat && \
     rm -rf /var/cache/yum
 
 LABEL version=0.10
@@ -17,12 +17,11 @@ RUN pip install --upgrade pip && \
 
 ARG repo_branch=${repo_branch:-master}
 ADD https://github.com/encryptme/private-end-points-docker-stats/archive/$repo_branch.zip /tmp/encryptme-metrics.zip
-RUN pip3 install /tmp/encryptme-metrics.zip && rm /tmp/encryptme-metrics.zip
+RUN pip3.4 install /tmp/encryptme-metrics.zip && rm /tmp/encryptme-metrics.zip
 
 ENV DISABLE_LETSENCRYPT 0
 
 ARG build_time=${build_time:-x}
 ADD files/ /
-
 
 ENTRYPOINT ["/run.sh"]

--- a/files/run.sh
+++ b/files/run.sh
@@ -177,7 +177,8 @@ fi
 
 # Gather server/config information (e.g. FQDNs, open VPN settings)
 rem "Getting server info"
-encryptme_server info --json | json_pp | tee "$ENCRYPTME_DATA_DIR/server.json"
+encryptme_server info --json
+encryptme_server info --json | jq -M | tee "$ENCRYPTME_DATA_DIR/server.json"
 if [ ! -s "$ENCRYPTME_DATA_DIR/server.json" ]; then
     fail "Failed to get or parse server 'info' API response" 5
 fi
@@ -198,7 +199,7 @@ if [ $DNS_CHECK -ne 0 ]; then
     EXTIP=$(curl --connect-timeout 5 -s http://169.254.169.254/latest/meta-data/public-ipv4)
     for hostname in $FQDNS; do
         rem "Checking DNS for FQDN '$hostname'"
-        DNS=`kdig +short A $hostname | egrep '^[0-9]+\.'`
+        DNS=`dig +short A $hostname | egrep '^[0-9]+\.'`
         if [ ! -z "$DNS" ]; then
             rem "Found IP '$DNS' for $hostname"
             if ip addr show | grep "$DNS" > /dev/null; then
@@ -254,8 +255,6 @@ if [ "$LETSENCRYPT_DISABLED" = 0 ]; then
         "${LE_ARGS[@]}"
         --expand
         --standalone
-        --standalone-supported-challenges
-        http-01
     )
 
     # temporarily allow in HTTP traffic to perform domain verification
@@ -406,4 +405,3 @@ while true; do
     date
     sleep 300
 done
-

--- a/files/run.sh
+++ b/files/run.sh
@@ -178,7 +178,7 @@ fi
 # Gather server/config information (e.g. FQDNs, open VPN settings)
 rem "Getting server info"
 encryptme_server info --json
-encryptme_server info --json | jq -M | tee "$ENCRYPTME_DATA_DIR/server.json"
+encryptme_server info --json | jq -M '.' | tee "$ENCRYPTME_DATA_DIR/server.json"
 if [ ! -s "$ENCRYPTME_DATA_DIR/server.json" ]; then
     fail "Failed to get or parse server 'info' API response" 5
 fi


### PR DESCRIPTION
looks like some epel dependencies have caused the upstream image to shift.

To reproduce run build.sh on a fresh system.

* Remove unneeded dependencies (knot, perl) in Dockerfile
* Resolve pip3.4 command name change from EPEL build
* Update certbot CLI for changes in certbot 0.33.0

Tested by building and running a private endpoint container on the latest centos 7 AMI.