### PR TITLE
Add encryptme.conf tuning to PEPS

### DIFF
--- a/files/run.sh
+++ b/files/run.sh
@@ -21,7 +21,7 @@ DNS_TEST_IP=${DNS_TEST_IP:-}
 LETSENCRYPT_DISABLED=${LETSENCRYPT_DISABLED:-0}
 LETSENCRYPT_STAGING=${LETSENCRYPT_STAGING:-0}
 SSL_EMAIL=${SSL_EMAIL:-}
-ENCRYPTME_TUNED_NETWORK=${ENCRYPTME_TUNED_NETWORK:-}
+ENCRYPTME_TUNE_NETWORK=${ENCRYPTME_TUNE_NETWORK:-}
 # misc opts
 VERBOSE=${ENCRYPTME_VERBOSE:-0}
 
@@ -84,7 +84,7 @@ cmd mkdir -p "$ENCRYPTME_DATA_DIR" \
     || fail "Failed to create Encrypt.me data dir '$ENCRYPTME_DATA_DIR'" 5
 
 # Inside the container creates /etc/sysctl.d/encryptme.conf with sysctl.conf tuning params.
-if [ "$ENCRYPTME_TUNED_NETWORK" = 1 ]; then
+if [ "$ENCRYPTME_TUNE_NETWORK" = 1 ]; then
     touch $ENCRYPTME_SYSCTL_CONF || fail "Failed to create encryptme.conf"
     cat > $ENCRYPTME_SYSCTL_CONF << EOF
 net.core.somaxconn=1024

--- a/files/run.sh
+++ b/files/run.sh
@@ -100,6 +100,8 @@ net.ipv4.tcp_slow_start_after_idle=0
 net.core.optmem_max=16777216
 net.netfilter.nf_conntrack_max=1008768
 EOF
+    # Load sysctl encryptme.conf
+    sysctl --load=$ENCRYPTME_SYSCTL_CONF
 fi
 
 # Run an configured Encrypt.me private end-point server (must have run 'config' first)

--- a/go.sh
+++ b/go.sh
@@ -26,7 +26,7 @@ dryrun=0
 non_interactive=0
 verbose=0
 restart=0
-tuned_network=0
+tune_network=0
 cert_type="letsencrypt"
 eme_img="encryptme/pep"  # TODO: finalize w/ Encryptme hub account
 wt_image="v2tec/watchtower"
@@ -71,7 +71,7 @@ GENERIC OPTIONS:
                           (default: $cert_type)
     -v|--verbose          Verbose debugging info
     -l|--logging          Enable some logging, eg IPSEC via /dev/log
-    -T|--tuned-network    Add 'sysctl.conf' tuning to 'encryptme.conf'
+    -T|--tune-network    Add 'sysctl.conf' tuning to 'encryptme.conf'
 
 INIT OPTIONS:
     --api-url URL         Use custom URL for Encrypt.me server API
@@ -193,7 +193,7 @@ server_init() {
         -e ENCRYPTME_STATS_SERVER=$stats_server \
         -e ENCRYPTME_STATS_ARGS="$stats_args" \
         -e ENCRYPTME_VERBOSE=$verbose \
-        -e ENCRYPTME_TUNED_NETWORK=$tuned_network \
+        -e ENCRYPTME_TUNE_NETWORK=$tune_network \
         -e INIT_ONLY=1 \
         -e DNS_TEST_IP="$dns_test_ip" \
         -e DNS_CHECK=$dns_check \
@@ -257,7 +257,7 @@ server_run() {
         -e ENCRYPTME_STATS=$send_stats \
         -e ENCRYPTME_STATS_SERVER=$stats_server \
         -e ENCRYPTME_STATS_ARGS="$stats_args" \
-        -e ENCRYPTME_TUNED_NETWORK=$tuned_network \
+        -e ENCRYPTME_TUNE_NETWORK=$tune_network \
         -v "$conf_dir:/etc/encryptme" \
         -v "$conf_dir/letsencrypt:/etc/letsencrypt" \
         -v /lib/modules:/lib/modules \
@@ -386,8 +386,8 @@ while [ $# -gt 0 ]; do
         --restart|-R)
             restart=1
             ;;
-        --tuned-network|-T)
-            tuned_network=1
+        --tune-network|-T)
+            tune_network=1
             ;;
         *)
             [ -n "$action" ] && fail "Invalid arg '$arg'; an action of '$action' was already given"

--- a/go.sh
+++ b/go.sh
@@ -26,6 +26,7 @@ dryrun=0
 non_interactive=0
 verbose=0
 restart=0
+tuned_network=0
 cert_type="letsencrypt"
 eme_img="encryptme/pep"  # TODO: finalize w/ Encryptme hub account
 wt_image="v2tec/watchtower"
@@ -70,6 +71,7 @@ GENERIC OPTIONS:
                           (default: $cert_type)
     -v|--verbose          Verbose debugging info
     -l|--logging          Enable some logging, eg IPSEC via /dev/log
+    -T|--tuned-network    Add 'sysctl.conf' tuning to 'encryptme.conf'
 
 INIT OPTIONS:
     --api-url URL         Use custom URL for Encrypt.me server API
@@ -191,6 +193,7 @@ server_init() {
         -e ENCRYPTME_STATS_SERVER=$stats_server \
         -e ENCRYPTME_STATS_ARGS="$stats_args" \
         -e ENCRYPTME_VERBOSE=$verbose \
+        -e ENCRYPTME_TUNED_NETWORK=$tuned_network \
         -e INIT_ONLY=1 \
         -e DNS_TEST_IP="$dns_test_ip" \
         -e DNS_CHECK=$dns_check \
@@ -254,6 +257,7 @@ server_run() {
         -e ENCRYPTME_STATS=$send_stats \
         -e ENCRYPTME_STATS_SERVER=$stats_server \
         -e ENCRYPTME_STATS_ARGS="$stats_args" \
+        -e ENCRYPTME_TUNED_NETWORK=$tuned_network \
         -v "$conf_dir:/etc/encryptme" \
         -v "$conf_dir/letsencrypt:/etc/letsencrypt" \
         -v /lib/modules:/lib/modules \
@@ -381,6 +385,9 @@ while [ $# -gt 0 ]; do
             ;;
         --restart|-R)
             restart=1
+            ;;
+        --tuned-network|-T)
+            tuned_network=1
             ;;
         *)
             [ -n "$action" ] && fail "Invalid arg '$arg'; an action of '$action' was already given"


### PR DESCRIPTION
- Adds /etc/sysctl.d/encryptme.conf file with next values and reloads `sysctl` inside the container:

> net.core.somaxconn=1024
> net.core.netdev_max_backlog=250000
> net.core.rmem_default=262144
> net.core.rmem_max=16777216
> net.core.wmem_default=262144
> net.core.wmem_max=16777216
> net.ipv4.tcp_rmem=262144 262144 16777216
> net.ipv4.tcp_wmem=262144 262144 16777216
> net.ipv4.tcp_max_syn_backlog=1000
> net.ipv4.tcp_slow_start_after_idle=0
> net.core.optmem_max=16777216
> net.netfilter.nf_conntrack_max=1008768
> 

[STRDEV-485](https://netprotect.atlassian.net/browse/STRDEV-485)