### PR TITLE
Enable forceencaps strongswan setting for NAT

### DIFF
--- a/files/etc/strongswan/ipsec.conf.j2
+++ b/files/etc/strongswan/ipsec.conf.j2
@@ -16,6 +16,7 @@ conn cloak
     esp = aes256gcm128-sha256,aes256gcm128-sha384,aes256gcm128-sha512,aes256-sha256,aes256-sha384,aes256-sha512,aes256-sha1,aes128gcm128-sha256,aes128gcm128-sha384,aes128gcm128-sha512,aes128-sha256,aes128-sha384,aes128-sha512,aes128-sha1!
     compress = yes
     fragmentation = yes
+    forceencaps = yes
 
     # leftid must match both the "Remote ID" requested by the client and the
     # server certificate. To keep things simple, we just use the server FQDN.


### PR DESCRIPTION
- Set `forceencaps = yes` by default on `ipsec.conf.j2`
 

[STRDEV-534](https://netprotect.atlassian.net/browse/STRDEV-534)