### PR TITLE
support nxdomain blocks and auto DoH blocking (#26)

### DIFF
--- a/to_copy/usr/local/unbound-1.7/sbin/filter_server.py
+++ b/to_copy/usr/local/unbound-1.7/sbin/filter_server.py
@@ -30,6 +30,7 @@ class FilterList():
         """
         Build entries from file.
         """
+        self.disable_doh = False
         self.blacklist = set()
         self.load(filters_dir)
 
@@ -47,6 +48,7 @@ class FilterList():
                 continue
             for domain in self._yield_lines(os.path.join(filters_dir, name)):
                 self.blacklist.add(domain)
+        self.disable_doh = bool(self.blacklist)
 
     def is_blocked(self, domain):
         '''
@@ -91,10 +93,9 @@ class FilterDaemon(Daemon):
                 data = connection.recv(2048)
                 if data:
                     request = json.loads(data)
-                    connection.sendall(json.dumps(
-                        filter_list.is_blocked(request['domain'].strip())
-                    ))
-
+                    is_blocked = filter_list.is_blocked(request['domain'].strip())
+                    disable_doh = filter_list.disable_doh
+                    connection.sendall(json.dumps((is_blocked, disable_doh)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Detect canary domain and responds with NXDOMAIN if blacklists exist

* Detect provider domains

* cleanup

* Avoid extra request and check if its provider and not blocked

Co-authored-by: Fernando Guerrero <fernando.guerrero@netprotect.com>